### PR TITLE
Support reading array props

### DIFF
--- a/api/examples/simple.rs
+++ b/api/examples/simple.rs
@@ -28,6 +28,12 @@ fn serialize_value(value: Value) -> String {
             serialize_value(value_for_key),
             serialize_value(value_for_other_key)
         )
+    } else if let Some(array_len) = value.array_len() {
+        let elements = (0..array_len)
+            .map(|i| serialize_value(value.get_at_index(i as u32)))
+            .collect::<Vec<String>>();
+
+        format!("array; [{}]", elements.join(", "))
     } else {
         "unknown value".to_string()
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -113,6 +113,11 @@ impl NanBox {
         Self::encode(code as _, 0, Tag::Error)
     }
 
+    /// Create a new NaN-boxed array.
+    pub fn array(ptr: usize, len: usize) -> Self {
+        Self::encode(ptr as _, len as _, Tag::Array)
+    }
+
     pub fn try_decode(&self) -> Result<ValueRef, Box<dyn Error>> {
         if self.0 & Self::NAN_MASK != Self::NAN_MASK {
             return Ok(ValueRef::Number(f64::from_bits(self.0)));
@@ -218,6 +223,10 @@ pub enum ErrorCode {
     PointerOutOfBounds = 2,
     /// An error occurred while attempting to read a value.
     ReadError = 3,
+    /// The value is not an array, but an operation expected an array.
+    NotAnArray = 4,
+    /// The index is out of bounds for the array.
+    IndexOutOfBounds = 5,
 }
 
 #[cfg(test)]

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -147,3 +147,27 @@ fn test_simple_with_obj_input() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn test_simple_with_array_input() -> Result<()> {
+    SIMPLE_EXAMPLE_RESULT
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
+
+    assert_eq!(
+        run_example_with_input("simple", serde_json::json!([]))?,
+        "got value array; []\n"
+    );
+
+    assert_eq!(
+        run_example_with_input("simple", serde_json::json!([42]))?,
+        "got value array; [42]\n"
+    );
+
+    let mixed_array_result =
+        run_example_with_input("simple", serde_json::json!([1, "string", true]))?;
+
+    assert_eq!(mixed_array_result, "got value array; [1, string, true]\n");
+
+    Ok(())
+}

--- a/trampoline/src/lib.rs
+++ b/trampoline/src/lib.rs
@@ -232,6 +232,10 @@ impl TrampolineCodegen {
         self.rename_imported_func("shopify_function_input_get", "_shopify_function_input_get")?;
         self.emit_shopify_function_input_read_utf8_str()?;
         self.emit_shopify_function_input_get_obj_prop()?;
+        self.rename_imported_func(
+            "shopify_function_input_get_at_index",
+            "_shopify_function_input_get_at_index",
+        )?;
         Ok(self.module)
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/Shopify/shopify-functions/issues/690
Part of: https://github.com/Shopify/shopify-functions/issues/637

Followed similar approach to https://github.com/Shopify/shopify-function-wasm-api/pull/7 (for objects).

This PR adds support for `arrays`, it handles all three array formats:
- fixarray: Small arrays with length in the marker byte
- array 16 (0xDC): Medium arrays with 2-byte length
- array 32 (0xDD): Large arrays with 4-byte length

For each format, we extract the array length and create a `NanBox` with a pointer to the array data and its length.

The `shopify_function_input_get_at_index`:
1. Decodes the NanBox to get the array pointer and length
2. Creates a reader for the array data
3. Parses the array header to determine the format and actual length
4. Performs bounds checking to ensure valid access (`IndexOutOfBounds`)
5. For index 0, we return the first element
6. For other indices, loop over and skips elements to reach the desired index
7. Returns appropriate errors for non-array values or out-of-bounds access

Tophatted this through integration tests. 


<details><summary>Notes on array types from</summary>

```
- fixarray (0x90 - 0x9F): For small arrays 
    - Format: 1001XXXX followed by elements
    - Length encoded in lower 4 bits of marker byte
- array 16 (0xDC): For medium arrays 
    - Format: 0xDC + 2-byte length + elements
    - Length encoded as 16-bit big-endian integer after marker
- array 32 (0xDD): For large arrays with up to 4,294,967,295 elements
    - Format: 0xDD + 4-byte length + elements
    - Length encoded as 32-bit big-endian integer after marker
```
For each format, we need to extract the length differently, but end result is the same: we create a NanBox that contains a pointer to the array data and its length.

</details>
