### PR TITLE
Use type aliases to unify API definitions

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,4 +1,7 @@
-use shopify_function_wasm_api_core::read::{NanBox, ValueRef};
+use shopify_function_wasm_api_core::{
+    read::{NanBox, Val, ValueRef},
+    write::{WriteContext, WriteResult},
+};
 
 mod write;
 pub use write::ValueSerializer;
@@ -6,17 +9,17 @@ pub use write::ValueSerializer;
 #[link(wasm_import_module = "shopify_function_v0.1.0")]
 extern "C" {
     // Read API.
-    fn shopify_function_input_get() -> u64;
+    fn shopify_function_input_get() -> Val;
     fn shopify_function_input_get_val_len(scope: u64) -> usize;
     fn shopify_function_input_read_utf8_str(src: usize, out: *mut u8, len: usize);
-    fn shopify_function_input_get_obj_prop(scope: u64, ptr: *const u8, len: usize) -> u64;
-    fn shopify_function_input_get_at_index(scope: u64, index: u32) -> u64;
+    fn shopify_function_input_get_obj_prop(scope: u64, ptr: *const u8, len: usize) -> Val;
+    fn shopify_function_input_get_at_index(scope: u64, index: u32) -> Val;
 
     // Write API.
-    fn shopify_function_output_new() -> usize;
-    fn shopify_function_output_new_bool(context: usize, bool: u32) -> u32;
-    fn shopify_function_output_new_null(context: usize) -> u32;
-    fn shopify_function_output_finalize(context: usize) -> u32;
+    fn shopify_function_output_new() -> WriteContext;
+    fn shopify_function_output_new_bool(context: usize, bool: u32) -> WriteResult;
+    fn shopify_function_output_new_null(context: usize) -> WriteResult;
+    fn shopify_function_output_finalize(context: usize) -> WriteResult;
 }
 
 pub enum Value {

--- a/api/src/write.rs
+++ b/api/src/write.rs
@@ -7,11 +7,10 @@ pub enum Error {
     IoError,
 }
 
-fn map_result(result: u32) -> Result<(), Error> {
-    match WriteResult::from_repr(result) {
-        Some(WriteResult::Ok) => Ok(()),
-        Some(WriteResult::IoError) => Err(Error::IoError),
-        None => panic!("Unknown write result: {}", result),
+fn map_result(result: WriteResult) -> Result<(), Error> {
+    match result {
+        WriteResult::Ok => Ok(()),
+        WriteResult::IoError => Err(Error::IoError),
     }
 }
 

--- a/core/src/read.rs
+++ b/core/src/read.rs
@@ -1,5 +1,8 @@
 use std::error::Error;
 
+/// A type alias to represent raw NaN-boxed values.
+pub type Val = u64;
+
 /// Values are represented as NaN-boxed values.
 ///
 /// As a recap, IEEE floats consist of:
@@ -15,7 +18,7 @@ use std::error::Error;
 /// For example:
 /// 1 11111111111 1[0..51]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct NanBox(u64);
+pub struct NanBox(Val);
 
 impl NanBox {
     /// The number of bits reserved for the payload.

--- a/core/src/write.rs
+++ b/core/src/write.rs
@@ -1,3 +1,6 @@
+/// The writer context used for serialization.
+pub type WriteContext = *mut std::ffi::c_void;
+
 #[repr(u32)]
 #[derive(Debug, strum::FromRepr)]
 pub enum WriteResult {

--- a/provider/src/write.rs
+++ b/provider/src/write.rs
@@ -1,15 +1,12 @@
 use core::ptr::NonNull;
 use rmp::encode::{self, ByteBuf};
-use shopify_function_wasm_api_core::write::WriteResult;
-use std::ffi::c_void;
+use shopify_function_wasm_api_core::write::{WriteContext as WriteContextPtr, WriteResult};
 use std::io::Write;
 
 #[derive(Default)]
 struct WriteContext {
     bytes: ByteBuf,
 }
-
-type WriteContextPtr = *mut c_void;
 
 fn write_context_from_raw(context: WriteContextPtr) -> NonNull<WriteContext> {
     unsafe { NonNull::new_unchecked(context as _) }


### PR DESCRIPTION
This commit annotates the return types via type aliases to ensure that the low-level ffi definitions correclty represent the intent in terms of input output.

Given that we also have definitions that return "pure" number types, like the length variants, this approach makes it clear the meaning of each return type.