### PR TITLE
Updates to use dev version `0.0.1`

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "shopify_function_wasm_api"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-shopify_function_wasm_api_core = { path = "../core", version = "0.1.0" }
+shopify_function_wasm_api_core = { path = "../core", version = "0.0.1" }
 thiserror = "2.0"
 
 [[example]]

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,7 +6,7 @@ use shopify_function_wasm_api_core::{
 mod write;
 pub use write::ValueSerializer;
 
-#[link(wasm_import_module = "shopify_function_v0.1.0")]
+#[link(wasm_import_module = "shopify_function_v0.0.1")]
 extern "C" {
     // Read API.
     fn shopify_function_input_get() -> Val;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_wasm_api_core"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_tests"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_wasm_api_provider"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [lib]
@@ -9,7 +9,7 @@ crate-type = ["lib", "cdylib"]
 [dependencies]
 once_cell = "1.20.3"
 rmp = "0.8.14"
-shopify_function_wasm_api_core = { path = "../core", version = "0.1.0" }
+shopify_function_wasm_api_core = { path = "../core", version = "0.0.1" }
 
 [dev-dependencies]
 paste = "1.0"

--- a/trampoline/Cargo.toml
+++ b/trampoline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_wasm_api_trampoline"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Updates version to be `0.0.1` indicating we are in development. Once versions are finalized, we will release `0.1.0`