### PR TITLE
Consume self on finalize output call to prevent additional usage

### DIFF
--- a/api/src/write.rs
+++ b/api/src/write.rs
@@ -78,7 +78,7 @@ impl Context {
         map_result(unsafe { crate::shopify_function_output_finish_array(self.0 as _) })
     }
 
-    pub fn finalize_output(&mut self) -> Result<(), Error> {
+    pub fn finalize_output(self) -> Result<(), Error> {
         map_result(unsafe { crate::shopify_function_output_finalize(self.0 as _) })
     }
 }


### PR DESCRIPTION
Simple change to the function signature so that the context cannot be used after calling the output finalize method