### PR TITLE
Benchmark WASM API 

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,6 +16,19 @@ shopify_function_provider = { path = "../provider", version = "1.0.0" }
 serde_json = "1.0"
 rmp-serde = "1.3"
 
+[dev-dependencies]
+serde_json = "1.0"
+rmp-serde = "1.1"
+
 [[example]]
 name = "echo"
 path = "examples/echo.rs"
+
+[[example]]
+name = "cart-checkout-validation-wasm-api"
+path = "examples/cart-checkout-validation-wasm-api.rs"
+
+[[example]]
+name = "cart-checkout-validation-wasi-json"
+path = "examples/cart-checkout-validation-wasi-json.rs"
+

--- a/api/examples/cart-checkout-validation-wasi-json.rs
+++ b/api/examples/cart-checkout-validation-wasi-json.rs
@@ -1,0 +1,63 @@
+use std::error::Error;
+use std::io::{self, Read, Write};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+
+    let input: serde_json::Value = serde_json::from_str(&buffer)?;
+
+    let errors = if let Some(cart) = input.get("cart") {
+        collect_errors(cart)
+    } else {
+        Vec::new()
+    };
+
+    let mut output = serde_json::Map::new();
+    let errors_array = errors
+        .into_iter()
+        .map(|msg| {
+            let mut error_obj = serde_json::Map::new();
+            error_obj.insert(
+                "localizedMessage".to_string(),
+                serde_json::Value::String(msg),
+            );
+            error_obj.insert(
+                "target".to_string(),
+                serde_json::Value::String("$.cart".to_string()),
+            );
+            serde_json::Value::Object(error_obj)
+        })
+        .collect();
+
+    output.insert("errors".to_string(), serde_json::Value::Array(errors_array));
+
+    let output_bytes = rmp_serde::to_vec(&serde_json::Value::Object(output))?;
+    io::stdout().write_all(&output_bytes)?;
+
+    Ok(())
+}
+
+fn collect_errors(cart: &serde_json::Value) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if !cart.is_object() {
+        return errors;
+    }
+
+    let lines = match cart.get("lines") {
+        Some(lines) if lines.is_array() => lines.as_array().unwrap(),
+        _ => return errors,
+    };
+
+    for line in lines {
+        if let Some(quantity) = line.get("quantity").and_then(|q| q.as_f64()) {
+            if quantity > 1.0 {
+                errors.push(String::from("Not possible to order more than one of each"));
+                break;
+            }
+        }
+    }
+
+    errors
+}

--- a/api/examples/cart-checkout-validation-wasm-api.rs
+++ b/api/examples/cart-checkout-validation-wasm-api.rs
@@ -1,0 +1,76 @@
+use shopify_function_wasm_api::{Context, Value};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut context = Context::new();
+
+    let input = context.input_get()?;
+    let cart = input.get_obj_prop("cart");
+
+    let errors = collect_errors(&cart);
+
+    context.write_object(
+        |ctx| {
+            ctx.write_utf8_str("errors")?;
+            ctx.write_array(
+                |array_ctx| {
+                    for error in &errors {
+                        array_ctx.write_object(
+                            |error_ctx| {
+                                error_ctx.write_utf8_str("localizedMessage")?;
+                                error_ctx.write_utf8_str(&error)?;
+
+                                error_ctx.write_utf8_str("target")?;
+                                error_ctx.write_utf8_str("$.cart")?;
+
+                                Ok(())
+                            },
+                            2,
+                        )?;
+                    }
+                    Ok(())
+                },
+                errors.len(),
+            )?;
+
+            Ok(())
+        },
+        1,
+    )?;
+
+    context.finalize_output()?;
+
+    Ok(())
+}
+
+// Helper function to collect errors for lines with quantity > 1
+fn collect_errors(cart: &Value) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if !cart.is_obj() {
+        return errors;
+    }
+
+    let lines = cart.get_obj_prop("lines");
+
+    if !lines.is_array() {
+        return errors;
+    }
+
+    if let Some(lines_len) = lines.array_len() {
+        for i in 0..lines_len {
+            let line = lines.get_at_index(i);
+            if line.is_obj() {
+                let quantity = line.get_obj_prop("quantity");
+                if let Some(q) = quantity.as_number() {
+                    if q > 1.0 {
+                        errors.push(String::from("Not possible to order more than one of each"));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    errors
+}

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -7,22 +7,58 @@ use wasmtime_wasi::{
     WasiCtxBuilder,
 };
 
-fn run_example_with_input(example: &str, input: serde_json::Value) -> Result<Vec<u8>> {
+const STARTING_FUEL: u64 = u64::MAX;
+const THRESHOLD_PERCENTAGE: f64 = 2.0;
+
+/// Used to detect any significant changes in the fuel consumption when making
+/// changes in Shopify Function Wasm API.
+///
+/// A threshold is used here so that we can decide how much of a change is
+/// acceptable. The threshold value needs to be sufficiently large enough to
+/// account for fuel differences between different operating systems.
+///
+/// We check for both increases and decreases in fuel consumption:
+/// - If fuel_consumed is significantly higher than target_fuel, we fail the test and ask to consider if the changes are worth the increase
+/// - If fuel_consumed is significantly lower than target_fuel, we show a message to double check the changes and update the target fuel if it's a legitimate improvement
+fn assert_fuel_consumed_within_threshold(target_fuel: u64, fuel_consumed: u64) {
+    let target_fuel = target_fuel as f64;
+    let fuel_consumed = fuel_consumed as f64;
+    let percentage_difference = ((fuel_consumed - target_fuel) / target_fuel).abs() * 100.0;
+
+    if fuel_consumed > target_fuel {
+        assert!(
+            percentage_difference <= THRESHOLD_PERCENTAGE,
+            "fuel_consumed ({}) was not within {:.2}% of the target_fuel value ({}). Please consider if the changes are worth the increase in fuel consumption.",
+            fuel_consumed,
+            THRESHOLD_PERCENTAGE,
+            target_fuel
+        );
+    } else if percentage_difference > THRESHOLD_PERCENTAGE {
+        assert!(
+            false,
+            "fuel_consumed ({}) was significantly better than target_fuel value ({}) by more than {:.2}%. This is a significant improvement! Please double check your changes and update the target fuel if this is a legitimate improvement.",
+            fuel_consumed,
+            target_fuel,
+            THRESHOLD_PERCENTAGE
+        );
+    }
+}
+
+fn run_example(example: &str, input_bytes: Vec<u8>) -> Result<(Vec<u8>, u64)> {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let workspace_root = std::path::PathBuf::from(manifest_dir).join("..");
-    let engine = Engine::new(&Config::new())?;
-    let module = Module::from_file(
-        &engine,
-        workspace_root.join(format!(
-            "target/wasm32-wasip1/release/examples/{example}.merged.wasm"
-        )),
-    )?;
+    let engine = Engine::new(&Config::new().consume_fuel(true))?;
+
+    let module_path = workspace_root.join(format!(
+        "target/wasm32-wasip1/release/examples/{example}.merged.wasm"
+    ));
+
+    let module = Module::from_file(&engine, workspace_root.join(module_path))?;
+
     let provider = Module::from_file(
         &engine,
         workspace_root.join("target/wasm32-wasip1/release/shopify_function_provider.wasm"),
     )?;
-
-    let input = rmp_serde::to_vec(&input)?;
 
     let mut linker = Linker::new(&engine);
     wasmtime_wasi::preview0::add_to_linker_sync(&mut linker, |ctx| ctx)
@@ -34,7 +70,7 @@ fn run_example_with_input(example: &str, input: serde_json::Value) -> Result<Vec
     deterministic_wasi_ctx::replace_scheduling_functions_for_wasi_preview_0(&mut linker)
         .expect("Failed to replace scheduling functions in wasi-ctx");
 
-    let stdin = MemoryInputPipe::new(input);
+    let stdin = MemoryInputPipe::new(input_bytes);
     let stderr = MemoryOutputPipe::new(usize::MAX);
     let stdout = MemoryOutputPipe::new(usize::MAX);
     let mut wasi_builder = WasiCtxBuilder::new();
@@ -44,8 +80,8 @@ fn run_example_with_input(example: &str, input: serde_json::Value) -> Result<Vec
         .stderr(stderr.clone());
     deterministic_wasi_ctx::add_determinism_to_wasi_ctx_builder(&mut wasi_builder);
     let wasi = wasi_builder.build_p1();
-
     let mut store = Store::new(&engine, wasi);
+    store.set_fuel(STARTING_FUEL)?;
 
     let provider_instance = linker.instantiate(&mut store, &provider)?;
     linker.instance(
@@ -60,6 +96,8 @@ fn run_example_with_input(example: &str, input: serde_json::Value) -> Result<Vec
 
     let result = func.call(&mut store, ());
 
+    let instructions = STARTING_FUEL.saturating_sub(store.get_fuel().unwrap_or_default());
+
     drop(store);
 
     if let Err(e) = result {
@@ -72,18 +110,57 @@ fn run_example_with_input(example: &str, input: serde_json::Value) -> Result<Vec
     }
 
     let output = stdout.contents().to_vec();
-    Ok(output)
+    Ok((output, instructions))
 }
 
-fn run_example_with_input_and_msgpack_output(
-    example: &str,
-    input: serde_json::Value,
-) -> Result<serde_json::Value> {
-    let output = run_example_with_input(example, input)?;
+fn decode_msgpack_output(output: Vec<u8>) -> Result<serde_json::Value> {
     Ok(rmp_serde::from_slice(&output)?)
 }
 
+fn decode_json_output(output: Vec<u8>) -> Result<serde_json::Value> {
+    match serde_json::from_slice(&output) {
+        Ok(json_value) => Ok(json_value),
+        Err(_) => match rmp_serde::from_slice(&output) {
+            Ok(msgpack_value) => Ok(msgpack_value),
+            Err(_) => match String::from_utf8(output.clone()) {
+                Ok(string_output) => {
+                    eprintln!(
+                        "Failed to parse output as JSON or MessagePack. Raw output: {}",
+                        string_output
+                    );
+                    Ok(serde_json::json!({ "raw_output": string_output }))
+                }
+                Err(_) => {
+                    eprintln!(
+                        "Output is not valid UTF-8. Raw binary length: {} bytes",
+                        output.len()
+                    );
+                    Ok(serde_json::json!({ "raw_output_length": output.len() }))
+                }
+            },
+        },
+    }
+}
+
+fn prepare_wasm_api_input(input: serde_json::Value) -> Result<Vec<u8>> {
+    Ok(rmp_serde::to_vec(&input)?)
+}
+
+fn prepare_wasi_json_input(input: serde_json::Value) -> Result<Vec<u8>> {
+    Ok(serde_json::to_vec(&input)?)
+}
+
+fn run_wasm_api_example(example: &str, input: serde_json::Value) -> Result<serde_json::Value> {
+    let input_bytes = prepare_wasm_api_input(input)?;
+    let (output, _fuel) = run_example(example, input_bytes)?;
+    decode_msgpack_output(output)
+}
+
 static ECHO_EXAMPLE_RESULT: LazyLock<Result<()>> = LazyLock::new(|| prepare_example("echo"));
+static BENCHMARK_EXAMPLE_RESULT: LazyLock<Result<()>> =
+    LazyLock::new(|| prepare_example("cart-checkout-validation-wasm-api"));
+static BENCHMARK_NON_WASM_API_EXAMPLE_RESULT: LazyLock<Result<()>> =
+    LazyLock::new(|| prepare_example("cart-checkout-validation-wasi-json"));
 
 #[test]
 fn test_echo_with_bool_input() -> Result<()> {
@@ -91,11 +168,11 @@ fn test_echo_with_bool_input() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!(true))?,
+        run_wasm_api_example("echo", serde_json::json!(true))?,
         serde_json::json!(true)
     );
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!(false))?,
+        run_wasm_api_example("echo", serde_json::json!(false))?,
         serde_json::json!(false)
     );
 
@@ -108,7 +185,7 @@ fn test_echo_with_null_input() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!(null))?,
+        run_wasm_api_example("echo", serde_json::json!(null))?,
         serde_json::json!(null)
     );
     Ok(())
@@ -121,7 +198,7 @@ fn test_echo_with_int_input() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     [0, 1, -1, i32::MAX, i32::MIN].iter().try_for_each(|&i| {
         assert_eq!(
-            run_example_with_input_and_msgpack_output("echo", serde_json::json!(i))?,
+            run_wasm_api_example("echo", serde_json::json!(i))?,
             serde_json::json!(i)
         );
         Ok(())
@@ -137,7 +214,7 @@ fn test_echo_with_float_input() -> Result<()> {
         .iter()
         .try_for_each(|&f| {
             assert_eq!(
-                run_example_with_input_and_msgpack_output("echo", serde_json::json!(f))?,
+                run_wasm_api_example("echo", serde_json::json!(f))?,
                 serde_json::json!(f)
             );
             Ok(())
@@ -150,7 +227,7 @@ fn test_echo_with_utf8_str_input() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!("Hello, world!"))?,
+        run_wasm_api_example("echo", serde_json::json!("Hello, world!"))?,
         serde_json::json!("Hello, world!")
     );
     Ok(())
@@ -162,10 +239,7 @@ fn test_echo_with_obj_input_with_interned_strings() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output(
-            "echo",
-            serde_json::json!({ "foo": 1, "bar": 2 })
-        )?,
+        run_wasm_api_example("echo", serde_json::json!({ "foo": 1, "bar": 2 }))?,
         serde_json::json!({ "foo": 1, "bar": 2 })
     );
     Ok(())
@@ -177,10 +251,7 @@ fn test_echo_with_obj_input_with_get_obj_prop() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output(
-            "echo",
-            serde_json::json!({ "abc": 1, "def": 2 })
-        )?,
+        run_wasm_api_example("echo", serde_json::json!({ "abc": 1, "def": 2 }))?,
         serde_json::json!({ "abc": 1, "def": 2 })
     );
     Ok(())
@@ -192,10 +263,7 @@ fn test_echo_with_obj_input_with_get_at_index() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output(
-            "echo",
-            serde_json::json!({ "uvw": 1, "xyz": 2 })
-        )?,
+        run_wasm_api_example("echo", serde_json::json!({ "uvw": 1, "xyz": 2 }))?,
         serde_json::json!({ "uvw": 1, "xyz": 2 })
     );
     Ok(())
@@ -207,10 +275,35 @@ fn test_echo_with_array_input() -> Result<()> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!([1, 2, 3]))?,
+        run_wasm_api_example("echo", serde_json::json!([1, 2, 3]))?,
         serde_json::json!([1, 2, 3])
     );
     Ok(())
+}
+
+/// Generates a cart with the specified number of items for testing.
+///
+/// # Arguments
+/// * `size` - The number of items to generate in the cart
+/// * `traverse_all` - Controls whether the cart validation should process all items or can exit early
+fn generate_cart_with_size(size: usize, traverse_all: bool) -> serde_json::Value {
+    let mut lines = Vec::with_capacity(size);
+
+    for i in 0..size {
+        lines.push(serde_json::json!({
+            "quantity": if traverse_all { 1 } else { 2 },
+            "merchandise": {
+                "id": format!("gid://shopify/ProductVariant/{}", i + 1),
+                "title": format!("Sample Product {}", i + 1)
+            }
+        }));
+    }
+
+    serde_json::json!({
+        "cart": {
+            "lines": lines
+        }
+    })
 }
 
 #[test]
@@ -220,7 +313,7 @@ fn test_echo_with_large_string_input() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
     let large_string = "a".repeat(u16::MAX as usize);
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!(large_string))?,
+        run_wasm_api_example("echo", serde_json::json!(large_string))?,
         serde_json::json!(large_string)
     );
 
@@ -236,8 +329,107 @@ fn test_echo_with_large_array_input() -> Result<()> {
 
     let large_array: Vec<i32> = (0..=u16::MAX as usize).map(|x| x as i32).collect();
     assert_eq!(
-        run_example_with_input_and_msgpack_output("echo", serde_json::json!(large_array))?,
+        run_wasm_api_example("echo", serde_json::json!(large_array))?,
         serde_json::json!(large_array)
     );
+    Ok(())
+}
+
+#[test]
+fn test_fuel_consumption_within_threshold() -> Result<()> {
+    BENCHMARK_EXAMPLE_RESULT
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
+    let input = generate_cart_with_size(2, true);
+    let wasm_api_input = prepare_wasm_api_input(input.clone())?;
+    let (_, wasm_api_fuel) = run_example("cart-checkout-validation-wasm-api", wasm_api_input)?;
+    eprintln!("WASM API fuel: {}", wasm_api_fuel);
+    // Using a target fuel value as reference similar to the Javy example
+    assert_fuel_consumed_within_threshold(16522, wasm_api_fuel);
+    Ok(())
+}
+
+#[test]
+fn test_benchmark_comparison_with_input() -> Result<()> {
+    BENCHMARK_EXAMPLE_RESULT
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
+    BENCHMARK_NON_WASM_API_EXAMPLE_RESULT
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("Failed to prepare non-WASM API example: {}", e))?;
+
+    let input = generate_cart_with_size(2, true);
+
+    let wasm_api_input = prepare_wasm_api_input(input.clone())?;
+    let (wasm_api_output, wasm_api_fuel) =
+        run_example("cart-checkout-validation-wasm-api", wasm_api_input)?;
+    let wasm_api_value = decode_msgpack_output(wasm_api_output)?;
+
+    let wasi_json_input = prepare_wasi_json_input(input)?;
+    let (non_wasm_api_output, non_wasm_api_fuel) =
+        run_example("cart-checkout-validation-wasi-json", wasi_json_input)?;
+    let non_wasm_api_value = decode_json_output(non_wasm_api_output)?;
+
+    assert_eq!(wasm_api_value, non_wasm_api_value);
+    assert!(
+        wasm_api_fuel < non_wasm_api_fuel,
+        "WASM API fuel usage ({}) should be less than non-WASM API fuel usage ({})",
+        wasm_api_fuel,
+        non_wasm_api_fuel
+    );
+
+    let improvement =
+        ((non_wasm_api_fuel as f64 - wasm_api_fuel as f64) / non_wasm_api_fuel as f64) * 100.0;
+    println!(
+        "WASM API fuel: {}, Non-WASM API fuel: {}, Improvement: {:.2}%",
+        wasm_api_fuel, non_wasm_api_fuel, improvement
+    );
+
+    assert_fuel_consumed_within_threshold(16522, wasm_api_fuel);
+    assert_fuel_consumed_within_threshold(26043, non_wasm_api_fuel);
+
+    Ok(())
+}
+
+#[test]
+fn test_benchmark_comparison_with_input_early_exit() -> Result<()> {
+    BENCHMARK_EXAMPLE_RESULT
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("Failed to prepare example: {}", e))?;
+    BENCHMARK_NON_WASM_API_EXAMPLE_RESULT
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("Failed to prepare non-WASM API example: {}", e))?;
+
+    let input = generate_cart_with_size(100, false);
+
+    let wasm_api_input = prepare_wasm_api_input(input.clone())?;
+    let (wasm_api_output, wasm_api_fuel) =
+        run_example("cart-checkout-validation-wasm-api", wasm_api_input)?;
+    let wasm_api_value = decode_msgpack_output(wasm_api_output)?;
+
+    let wasi_json_input = prepare_wasi_json_input(input)?;
+    let (non_wasm_api_output, non_wasm_api_fuel) =
+        run_example("cart-checkout-validation-wasi-json", wasi_json_input)?;
+    let non_wasm_api_value = decode_json_output(non_wasm_api_output)?;
+
+    assert_eq!(wasm_api_value, non_wasm_api_value);
+    assert!(
+        wasm_api_fuel < non_wasm_api_fuel,
+        "WASM API fuel usage ({}) should be less than non-WASM API fuel usage ({})",
+        wasm_api_fuel,
+        non_wasm_api_fuel
+    );
+
+    let improvement =
+        ((non_wasm_api_fuel as f64 - wasm_api_fuel as f64) / non_wasm_api_fuel as f64) * 100.0;
+    println!(
+        "WASM API fuel: {}, Non-WASM API fuel: {}, Improvement: {:.2}%",
+        wasm_api_fuel, non_wasm_api_fuel, improvement
+    );
+
+    // Add fuel consumption threshold checks for both implementations
+    assert_fuel_consumed_within_threshold(18486, wasm_api_fuel);
+    assert_fuel_consumed_within_threshold(807817, non_wasm_api_fuel);
+
     Ok(())
 }


### PR DESCRIPTION
https://github.com/shop/issues-shopifyvm/issues/256

This test will benchmark a WASM API function and a normal function. The function that is used in this PR is the default cart-checkout-validation [here](https://github.com/Shopify/function-examples/blob/main/checkout/rust/cart-checkout-validation/default/src/run.rs)

Note: Currently not asserting fuel usage in the non-early-exit case since it would fail. We can address in future iterations or wait before merging this. Currently, with the example it shows more fuel usage. 

### Tests
- New benchmark tests verify both implementations produce identical outputs
- Early exit test ensures WASM API is more efficient when possible
- Full traversal test tracks performance in worst-case scenario
- I haven't added an assertion for acceptable range which the WASM should run with in yet. As it currently looks faster in some cases, and slower in others. We can improve this with future iterations.

- Anything else we should test or assert on?

Note: Ran into an issue with msgpack array access - updated the `msgpack_input.rs` to check for array length before pushing. The error I saw was:

```
STDERR:

thread '<unnamed>' panicked at provider/src/read/msgpack_input.rs:246:17:
assertion failed: index == value_jumps.len()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```