### PR TITLE
Add required open source project files

### DIFF
--- a/.github/workflows/cla.yml 
+++ b/.github/workflows/cla.yml 
@@ -1,0 +1,24 @@
+# .github/workflows/cla.yml
+name: Contributor License Agreement (CLA)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.issue.pull_request
+        && !github.event.issue.pull_request.merged_at
+        && contains(github.event.comment.body, 'signed')
+      )
+|| (github.event.pull_request && !github.event.pull_request.merged)
+    steps:
+      - uses: Shopify/shopify-cla-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cla-token: ${{ secrets.CLA_TOKEN }}
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+opensource@shopify.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Shopify Function WASM API
+
+Thank you for your interest in contributing to the Shopify Function WASM API! This document provides guidelines and instructions for contributing to this project.
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## How to Contribute
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## Contributor License Agreement
+
+Before we can accept your contributions, you need to sign our Contributor License Agreement (CLA). This will be automatically checked when you open a pull request. If you haven't signed the CLA, you'll be prompted to do so.
+
+## Code Review Process
+
+All code submissions require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests.
+
+## Development Setup
+
+Please refer to the README.md for instructions on setting up your development environment.
+
+## Questions or Issues?
+
+If you have any questions or run into any issues, please open an issue in the GitHub repository.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2025-present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# Shopify Function Wasm API
+# Shopify Function WASM API
+
+A high-performance API for building Shopify Functions using WebAssembly (WASM).
+
+## Architecture
+
+The WASM API consists of these main components:
+
+1. **Provider (`provider/`)**
+    - Implements low-level WASM operations for:
+        - Reading function input
+        - Serializing the function output
+
+2. **Core (`core/`)**
+    - Defines common types used by the `providers` and `api`
+
+3. **API (`api/`)**
+    - Provides a high-level interface for interacting with the provider
+    - Abstracts away low-level WASM details
+    - Includes examples and documentation
+
+4. **Trampoline (`trampoline/`)**
+    - CLI tool that augments WASM modules to interface with the provider
+    - Handles memory sharing between guest and provider modules
+    - Creates the necessary WASM imports/exports
+
+## Getting Started
+
+### Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install) (latest stable version)
+
+### Basic Usage
+
+Here's a simple example of how to use the API:
+
+```rust
+fn main(context: &mut Context) -> Result<()> {
+    let input = context.input_get()?;
+
+    // Function logic
+
+    context.finalize_output()?;
+    
+    Ok(())
+}
+```
+
+To build a function example, create a new example and build it targeting `wasm32-wasip1`:
+
+```shell
+cargo build --release --target wasm32-wasip1 -p shopify_function_wasm_api --example echo
+```
+
+
+The trampoline tool bridges communication between your Wasm module and the provider module. To trampoline your Wasm module:
+
+```shell
+# Short flags
+cargo run -p shopify_function_wasm_api_trampoline -- -i input.wasm -o output.wasm
+```
+
+For examples, check out the [examples directory](./api/examples/).
+
+## Documentation
+
+For more detailed documentation, refer to:
+
+- [Examples](./api/examples)
+- [Integration Tests](./integration_tests/tests/integration_test.rs)
+
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guide](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md) before submitting a pull request.
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE.md).


### PR DESCRIPTION
Addresses: https://github.com/shop/issues-shopifyvm/issues/235

Followed section 2.5 in [vault docs for making a repo public](https://vault.shopify.io/page/Open-source~dhb2b7f.md#a-nameoutgoinga20-starting-a-new-open-source-project-with-shopify-code), this PR adds the following suggested files for making a repository public at Shopify:

#### Done
- [x] Add required files:
     - [x] add README.md 
    - [x] add CONTRIBUTING.md -> I didn't see requirements for this in the docs
    - [x] add CODE_OF_CONDUCT.md file -> same as function-runner
    - [x] add License.md -> copied from vault
    - [x] add CLA workflow -> copied from vault

#### WIP
- [x] Documentation
    - [x] Ensure README.md is comprehensive (2.8)

#### [TODO] before making repo public
- [x] Verify CLA
    - [x] todo: after this merges. Settings > Code and automation > Branches and change default branch protection rules for CLA to be a required status check. (Step 2.5)
    - [x] verify at https://github.com/Shopify/shopify-cla-action
        - note: check it shows on PR's, it looks like a status check
- [x] Code Hygiene (2.6)
    - [x] Verify no Shopify platform info is exposed (except for examples)
- [x] Branch Protection (2.9)
    - [x] Set up branch protection rules for main branch
    - [x] Configure codeowner reviews
    - [x] https://shopify.slack.com/archives/C08B8KXPAQZ/p1745952085774489?thread_ts=1745951497.483349&cid=C08B8KXPAQZ
- [ ] Project Listing (2.10)
    - [ ] ensure project listed in Shopify open source directory
    - [ ] small PR adding `shopify-function-wasm-api` here
    - [ ] https://github.com/Shopify/shopify.github.com/pull/127
- [x] Stewardship (2.4)
    - [x] ensure project maintainers
    - [x] project in ServicesDB
    - [x] https://services.shopify.io/services/shopify-function-wasm-api
