### PR TITLE
Allow interning strings off of `Value`

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -82,6 +82,13 @@ pub struct Value {
 }
 
 impl Value {
+    pub fn intern_utf8_str(&self, s: &str) -> InternedStringId {
+        let len = s.len();
+        let ptr = s.as_ptr();
+        let id = unsafe { shopify_function_intern_utf8_str(self.context.as_ptr() as _, ptr, len) };
+        InternedStringId(id)
+    }
+
     pub fn as_bool(&self) -> Option<bool> {
         match self.nan_box.try_decode() {
             Ok(ValueRef::Bool(b)) => Some(b),


### PR DESCRIPTION
For the Rust codegen, we won't always have a context pointer easily accessible, but we will have a `Value` (which contains a context pointer), so this exposes a `intern_utf8_str` function on the value to make string interning easy when you have a `Value`