### PR TITLE
Use provider for rust target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,16 @@ jobs:
         run: cargo fmt --check
       - name: Run clippy
         run: cargo clippy --all-features -- -D warnings
+      - name: Run clippy (wasm32-wasip1 target)
+        run: cargo clippy --target wasm32-wasip1 --all-features --workspace --exclude shopify_function_wasm_api_trampoline --exclude integration_tests -- -D warnings
       - name: Run clippy (tests)
         run: cargo clippy --tests --all-features
       - name: Run clippy (benches)
         run: cargo clippy --benches --all-features
       - name: Run clippy (examples)
         run: cargo clippy --examples --all-features
+      - name: Run clippy (examples, wasm32-wasip1 target)
+        run: cargo clippy --examples --target wasm32-wasip1 --all-features
 
   test:
     runs-on: shopify-ubuntu-latest
@@ -55,9 +59,9 @@ jobs:
             cargo-target-${{ hashFiles('Cargo.toml') }}
             cargo-target
       - name: Run tests
-        # we exclude the api crate because it cannot be tested in isolation
-        # due to needing the trampoline wasm to be merged into it
-        run: cargo test --workspace --exclude shopify_function_wasm_api
+        run: cargo test
+      - name: Run tests (examples)
+        run: cargo test --examples
 
   build:
     runs-on: shopify-ubuntu-latest

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 shopify_function_wasm_api_core = { path = "../core", version = "0.0.1" }
 thiserror = "2.0"
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+shopify_function_wasm_api_provider = { path = "../provider", version = "0.0.1" }
+serde_json = "1.0"
+rmp-serde = "1.3"
+
 [[example]]
 name = "echo"
 path = "examples/echo.rs"

--- a/api/examples/echo.rs
+++ b/api/examples/echo.rs
@@ -20,6 +20,7 @@ fn echo(value: Value) -> Value {
     value
 }
 
+#[derive(Debug, PartialEq)]
 enum Value {
     Null,
     Bool(bool),
@@ -111,5 +112,27 @@ impl Serialize for Value {
                 arr.len(),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_echo() {
+        let input = serde_json::json!({});
+        let context = Context::new_with_input(input);
+        let api_value = context.input_get().unwrap();
+        let input: Value = Deserialize::deserialize(&api_value).unwrap();
+        let result = echo(input);
+
+        assert_eq!(
+            result,
+            Value::Object {
+                foo_value: Box::new(Value::Null),
+                bar_value: Box::new(Value::Null),
+            }
+        );
     }
 }

--- a/core/src/read.rs
+++ b/core/src/read.rs
@@ -1,6 +1,9 @@
 use std::error::Error;
 
 /// A type alias to represent raw NaN-boxed values.
+#[cfg(target_pointer_width = "64")]
+pub type Val = u128;
+#[cfg(target_pointer_width = "32")]
 pub type Val = u64;
 
 /// Values are represented as NaN-boxed values.
@@ -21,32 +24,37 @@ pub type Val = u64;
 pub struct NanBox(Val);
 
 impl NanBox {
+    /// The number of bits to left shift an f64 to place it in a Nan-boxed value, and similarly right shift a `Val` to get an f64 out of a Nan-boxed value.
+    /// For a 32-bit architecture, this is 0 because the Nan-boxed value is 64-bits.
+    /// For a 64-bit architecture, this is 64 because the Nan-boxed value is 128-bits and we want the f64 to be in the most significant 64 bits.
+    const F64_OFFSET: u8 = Val::BITS as u8 - 64;
     /// The number of bits reserved for the payload.
     /// The payload includes:
     /// * 32 bits for the value encoding
     /// * 14 bits for value encoding metadata. The value encoding length.
     /// * 4 bits for the value tag.
-    const PAYLOAD_SIZE: u8 = 50;
+    const PAYLOAD_SIZE: u8 = 50 + Self::F64_OFFSET;
     /// The number of bits reserved for the mantissa.
     const MANTISSA_SIZE: u8 = 52;
     /// The number of bits reserved for the quiet NaN.
-    const QUIET_NAN_SIZE: u8 = Self::MANTISSA_SIZE - Self::PAYLOAD_SIZE;
+    const QUIET_NAN_SIZE: u8 = Self::MANTISSA_SIZE + Self::F64_OFFSET - Self::PAYLOAD_SIZE;
     /// The number of bits reserved for the exponent.
     const EXPONENT_SIZE: u8 = 11;
     /// The NaN-pattern to represent NaN-boxed values.
     /// | 0 - Sign bit | 11 - Exponent (all 1) | 2 - quiet NaN | 50 Payload |
-    const NAN_MASK: u64 =
+    const NAN_MASK: Val =
         ((1 << (Self::QUIET_NAN_SIZE + Self::EXPONENT_SIZE)) - 1) << Self::PAYLOAD_SIZE;
     /// Mask to retrieve the [`Self::PAYLOAD_SIZE`] bits.
     // We want the LS 50 bits to be 1.
-    const PAYLOAD_MASK: u64 = !(Self::NAN_MASK | (1 << 63));
+    const PAYLOAD_MASK: Val =
+        !(Self::NAN_MASK | (1 << (Self::MANTISSA_SIZE + Self::EXPONENT_SIZE + Self::F64_OFFSET)));
     /// The number of bits reserved for the payload tag.
     const TAG_SIZE: u8 = 4;
     /// The maximum number that can be encoded in the number of bits reserved for
     /// [`TAG_SIZE`].
     const MAX_TAG_VALUE: u8 = (1 << Self::TAG_SIZE) - 1;
     /// Mask to retrieve the [`Self::TAG_SIZE`] bits.
-    const TAG_MASK: u64 = (Self::MAX_TAG_VALUE as u64) << Self::VALUE_SIZE;
+    const TAG_MASK: Val = (Self::MAX_TAG_VALUE as Val) << Self::VALUE_SIZE;
     /// The number of bits reserved for the value encoding.
     /// Effectively 46 bits, which can contain:
     /// * The value encoded in the least significant 32-bits.
@@ -55,7 +63,7 @@ impl NanBox {
     /// The number of bits reserved for the value encoding.
     /// 32 is the max number of bits given that 32-bit is the Wasm address space,
     /// which represents the pointer size of 32-bit architectures.
-    const VALUE_ENCODING_SIZE: u8 = 32;
+    const VALUE_ENCODING_SIZE: u8 = usize::BITS as u8;
     /// The number of bits reserved for the value length metadata of the value
     /// encoding.
     /// If the value is a string, this value represents the length of the string, in
@@ -65,21 +73,21 @@ impl NanBox {
     /// The maximum number that can be encoed in the number of bits reserved for
     /// [`Self::VALUE_LENGTH_SIZE`].
     /// This is (2^14) - 1.
-    pub const MAX_VALUE_LENGTH: u64 = (1 << Self::VALUE_LENGTH_SIZE) - 1;
+    pub const MAX_VALUE_LENGTH: usize = (1 << Self::VALUE_LENGTH_SIZE) - 1;
     /// Mask to retrive the value from the payload.
-    const VALUE_MASK: u64 = Self::PAYLOAD_MASK & !Self::TAG_MASK;
+    const VALUE_MASK: Val = Self::PAYLOAD_MASK & !Self::TAG_MASK;
     /// Mask to retrive the pointer from the value, in the case that the value is
     /// an array or a string. Assumes that the value has already been masked by
     /// [`Self::VALUE_MASK`].
-    const POINTER_MASK: u64 = u32::MAX as u64;
+    const POINTER_MASK: Val = (1 << Self::VALUE_ENCODING_SIZE as Val) - 1;
 
     /// Retrieves the inner representation of the value.
-    pub fn to_bits(&self) -> u64 {
+    pub fn to_bits(&self) -> Val {
         self.0
     }
 
-    /// Creates a NaN-boxed value from a raw u64.
-    pub fn from_bits(val: u64) -> Self {
+    /// Creates a NaN-boxed value from a raw `Val`.
+    pub fn from_bits(val: Val) -> Self {
         Self(val)
     }
 
@@ -97,7 +105,7 @@ impl NanBox {
     /// Create a new NaN-boxed number.
     pub fn number(val: f64) -> Self {
         assert!(!val.is_nan());
-        Self(val.to_bits())
+        Self((val.to_bits() as Val) << Self::F64_OFFSET)
     }
 
     /// Create a new NaN-boxed string.
@@ -122,7 +130,11 @@ impl NanBox {
 
     pub fn try_decode(&self) -> Result<ValueRef, Box<dyn Error>> {
         if self.0 & Self::NAN_MASK != Self::NAN_MASK {
-            return Ok(ValueRef::Number(f64::from_bits(self.0)));
+            #[cfg(target_pointer_width = "32")]
+            let value = self.0;
+            #[cfg(target_pointer_width = "64")]
+            let value = (self.0 >> Self::F64_OFFSET) as u64;
+            return Ok(ValueRef::Number(f64::from_bits(value)));
         }
 
         let val = self.0 & Self::VALUE_MASK;
@@ -149,14 +161,13 @@ impl NanBox {
 
     fn tag(&self) -> Result<Tag, Box<dyn Error>> {
         let tag = (self.0 & Self::PAYLOAD_MASK) >> Self::VALUE_SIZE;
-        Tag::from_u64(tag)
+        Tag::from_val(tag)
     }
 
-    fn encode(ptr: u64, len: u64, tag: Tag) -> Self {
-        let trimmed_len = len.min(Self::MAX_VALUE_LENGTH);
-        let ptr = ptr & Self::POINTER_MASK;
-        let val = (trimmed_len << Self::VALUE_ENCODING_SIZE) | ptr;
-        Self(Self::NAN_MASK | (tag.as_u64() << Self::VALUE_SIZE) | val)
+    fn encode(ptr: usize, len: usize, tag: Tag) -> Self {
+        let trimmed_len = len.min(Self::MAX_VALUE_LENGTH) as Val;
+        let val = (trimmed_len << Self::VALUE_ENCODING_SIZE) | (ptr as Val & Self::POINTER_MASK);
+        Self(Self::NAN_MASK | (tag.as_val() << Self::VALUE_SIZE) | val)
     }
 }
 
@@ -192,11 +203,11 @@ enum Tag {
 }
 
 impl Tag {
-    fn as_u64(&self) -> u64 {
-        *self as u64
+    fn as_val(&self) -> Val {
+        *self as Val
     }
 
-    fn from_u64(v: u64) -> Result<Self, Box<dyn Error>> {
+    fn from_val(v: Val) -> Result<Self, Box<dyn Error>> {
         match u8::try_from(v) {
             Ok(v) => Self::from_repr(v).ok_or_else(|| format!("Unknown tag: {}", v).into()),
             Err(_) => Err(format!("Unknown tag: {}", v).into()),
@@ -240,7 +251,7 @@ mod tests {
             assert!(NanBox::NAN_MASK & (1 << i) == 0);
         }
 
-        for i in NanBox::PAYLOAD_SIZE..63 {
+        for i in NanBox::PAYLOAD_SIZE..(Val::BITS as u8 - 1) {
             assert!(NanBox::NAN_MASK & (1 << i) != 0);
         }
 
@@ -249,16 +260,17 @@ mod tests {
 
     #[test]
     fn test_nan_mask_and_stdlib_f64_nan_constants_align() {
+        let nan_mask = (NanBox::NAN_MASK >> NanBox::F64_OFFSET) as u64;
         for std_nan in &[f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             let std_nan_without_sign = std_nan.to_bits() & !(1 << 63);
-            let masked = NanBox::NAN_MASK & std_nan.to_bits();
+            let masked = nan_mask & std_nan.to_bits();
             assert_eq!(masked, std_nan_without_sign);
         }
     }
 
     #[test]
     fn test_nan_mask_is_f64_nan() {
-        assert!(f64::from_bits(NanBox::NAN_MASK).is_nan());
+        assert!(f64::from_bits((NanBox::NAN_MASK >> NanBox::F64_OFFSET) as u64).is_nan());
     }
 
     #[test]
@@ -267,7 +279,7 @@ mod tests {
             assert!(NanBox::PAYLOAD_MASK & (1 << i) != 0);
         }
 
-        for i in NanBox::PAYLOAD_SIZE..64 {
+        for i in NanBox::PAYLOAD_SIZE..(Val::BITS as u8) {
             assert!(NanBox::PAYLOAD_MASK & (1 << i) == 0);
         }
     }
@@ -282,7 +294,7 @@ mod tests {
             assert!(NanBox::TAG_MASK & (1 << i) != 0);
         }
 
-        for i in NanBox::PAYLOAD_SIZE..64 {
+        for i in NanBox::PAYLOAD_SIZE..(Val::BITS as u8) {
             assert!(NanBox::TAG_MASK & (1 << i) == 0);
         }
     }

--- a/dev.yml
+++ b/dev.yml
@@ -7,13 +7,22 @@ up:
 
 commands:
   test:
-    run: cargo test --workspace --exclude shopify_function_wasm_api
+    run: |
+      cargo test
+      cargo test --examples
   style:
     run: |
       cargo fmt
       cargo clippy --all-features -- -D warnings
+      cargo clippy --target wasm32-wasip1 --all-features --workspace --exclude shopify_function_wasm_api_trampoline --exclude integration_tests -- -D warnings
       cargo clippy --tests --all-features
       cargo clippy --benches --all-features
       cargo clippy --examples --all-features
+      cargo clippy --examples --target wasm32-wasip1 --all-features
   build:
     run: cargo build --release --all-features
+
+check:
+  test: /opt/dev/bin/dev test
+  style: /opt/dev/bin/dev style
+  build: /opt/dev/bin/dev build

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -84,8 +84,6 @@ fn run_example_with_input_and_msgpack_output(
 }
 
 static ECHO_EXAMPLE_RESULT: LazyLock<Result<()>> = LazyLock::new(|| prepare_example("echo"));
-static SERIALIZATION_EXAMPLE_RESULT: LazyLock<Result<()>> =
-    LazyLock::new(|| prepare_example("serialization"));
 
 #[test]
 fn test_echo_with_bool_input() -> Result<()> {

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -1,15 +1,20 @@
 mod alloc;
-mod read;
+pub mod read;
 mod string_interner;
-mod write;
+pub mod write;
 
 use rmp::encode::ByteBuf;
 use shopify_function_wasm_api_core::ContextPtr;
-use std::{io::Read, ptr::NonNull};
+use std::ptr::NonNull;
 use string_interner::StringInterner;
 use write::State;
 
 pub const PROVIDER_MODULE_NAME: &str = concat!("shopify_function_v", env!("CARGO_PKG_VERSION"));
+
+#[cfg(target_pointer_width = "64")]
+type DoubleUsize = u128;
+#[cfg(target_pointer_width = "32")]
+type DoubleUsize = u64;
 
 struct Context {
     bump_allocator: bumpalo::Bump,
@@ -38,7 +43,9 @@ impl Context {
         }
     }
 
+    #[cfg(target_family = "wasm")]
     fn new_from_stdin() -> Self {
+        use std::io::Read;
         let mut input_bytes: Vec<u8> = vec![];
         let mut stdin = std::io::stdin();
         // Temporary use of stdin, to copy data into the Wasm linear memory.
@@ -62,18 +69,45 @@ impl Context {
     }
 }
 
+macro_rules! decorate_for_target {
+    ($(#[doc = $docs:tt])? fn $fn_name:ident($($args:tt)*) -> $ret:ty {
+        $($body:tt)*
+    }) => {
+        #[cfg(target_family = "wasm")]
+        $(#[doc = $docs])?
+        #[export_name = concat!("_", stringify!($fn_name))]
+        extern "C" fn $fn_name($($args)*) -> $ret {
+            $($body)*
+        }
+        #[cfg(not(target_family = "wasm"))]
+        $(#[doc = $docs])?
+        pub fn $fn_name($($args)*) -> $ret {
+            $($body)*
+        }
+    }
+}
+
+pub(crate) use decorate_for_target;
+
+#[cfg(target_family = "wasm")]
 #[export_name = "_shopify_function_context_new"]
 extern "C" fn shopify_function_context_new() -> ContextPtr {
     Box::into_raw(Box::new(Context::new_from_stdin())) as _
 }
 
-#[export_name = "_shopify_function_intern_utf8_str"]
-extern "C" fn shopify_function_intern_utf8_str(context: ContextPtr, len: usize) -> u64 {
-    match Context::mut_from_raw(context) {
-        Ok(context) => {
+#[cfg(not(target_family = "wasm"))]
+pub fn shopify_function_context_new_from_msgpack_bytes(bytes: Vec<u8>) -> ContextPtr {
+    Box::into_raw(Box::new(Context::new(bytes))) as _
+}
+
+decorate_for_target! {
+    fn shopify_function_intern_utf8_str(context: ContextPtr, len: usize) -> DoubleUsize {
+        match Context::mut_from_raw(context) {
+            Ok(context) => {
             let (id, ptr) = context.string_interner.preallocate(len);
-            ((id as u64) << 32) | (ptr as u64)
+                ((id as DoubleUsize) << usize::BITS) | (ptr as DoubleUsize)
+            }
+            Err(_) => 0,
         }
-        Err(_) => 0,
     }
 }

--- a/provider/src/read.rs
+++ b/provider/src/read.rs
@@ -1,7 +1,7 @@
-use crate::Context;
+use crate::{decorate_for_target, Context};
 use shopify_function_wasm_api_core::ContextPtr;
 use shopify_function_wasm_api_core::{
-    read::{ErrorCode, NanBox, ValueRef as NanBoxValueRef},
+    read::{ErrorCode, NanBox, Val, ValueRef as NanBoxValueRef},
     InternedStringId,
 };
 
@@ -9,152 +9,161 @@ mod lazy_value_ref;
 
 pub(crate) use lazy_value_ref::LazyValueRef;
 
-#[export_name = "_shopify_function_input_get"]
-extern "C" fn shopify_function_input_get(context: ContextPtr) -> u64 {
-    match Context::ref_from_raw(context) {
-        Ok(context) => {
-            match context.bump_allocator.alloc_try_with(|| {
-                LazyValueRef::new(&context.input_bytes, 0, &context.bump_allocator)
-                    .map(|(value, _)| value)
-            }) {
-                Ok(input_ref) => input_ref.encode().to_bits(),
-                Err(e) => NanBox::error(e).to_bits(),
-            }
+decorate_for_target! {
+    fn shopify_function_input_get(context: ContextPtr) -> Val {
+        match Context::ref_from_raw(context) {
+            Ok(context) => {
+                match context.bump_allocator.alloc_try_with(|| {
+                    LazyValueRef::new(&context.input_bytes, 0, &context.bump_allocator)
+                        .map(|(value, _)| value)
+                }) {
+                    Ok(input_ref) => input_ref.encode().to_bits(),
+                    Err(e) => NanBox::error(e).to_bits(),
+                }
         }
-        Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
+            Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
+        }
     }
 }
 
-#[export_name = "_shopify_function_input_get_obj_prop"]
-extern "C" fn shopify_function_input_get_obj_prop(
-    context: ContextPtr,
-    scope: u64,
-    ptr: usize,
-    len: usize,
-) -> u64 {
-    match Context::ref_from_raw(context) {
-        Ok(context) => {
-            let v = NanBox::from_bits(scope);
-            match v.try_decode() {
-                Ok(NanBoxValueRef::Object { ptr: obj_ptr }) => {
-                    let query = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
-                    let value = match LazyValueRef::mut_from_raw(obj_ptr as _) {
-                        Ok(value) => value,
-                        Err(e) => return NanBox::error(e).to_bits(),
-                    };
-                    match value.get_object_property(
-                        query,
-                        &context.input_bytes,
-                        &context.bump_allocator,
-                    ) {
-                        Ok(Some(value)) => value.encode().to_bits(),
-                        Ok(None) => NanBox::null().to_bits(),
-                        Err(e) => NanBox::error(e).to_bits(),
+decorate_for_target! {
+    fn shopify_function_input_get_obj_prop(
+        context: ContextPtr,
+        scope: Val,
+        ptr: usize,
+        len: usize,
+    ) -> Val {
+        match Context::ref_from_raw(context) {
+            Ok(context) => {
+                let v = NanBox::from_bits(scope);
+                match v.try_decode() {
+                    Ok(NanBoxValueRef::Object { ptr: obj_ptr }) => {
+                        let query = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+                        let value = match LazyValueRef::mut_from_raw(obj_ptr as _) {
+                            Ok(value) => value,
+                            Err(e) => return NanBox::error(e).to_bits(),
+                        };
+                        match value.get_object_property(
+                            query,
+                            &context.input_bytes,
+                            &context.bump_allocator,
+                        ) {
+                            Ok(Some(value)) => value.encode().to_bits(),
+                            Ok(None) => NanBox::null().to_bits(),
+                            Err(e) => NanBox::error(e).to_bits(),
+                        }
                     }
+                    Ok(_) => NanBox::error(ErrorCode::NotAnObject).to_bits(),
+                    Err(_) => NanBox::error(ErrorCode::DecodeError).to_bits(),
                 }
-                Ok(_) => NanBox::error(ErrorCode::NotAnObject).to_bits(),
-                Err(_) => NanBox::error(ErrorCode::DecodeError).to_bits(),
             }
+            Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
         }
-        Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
     }
 }
 
-#[export_name = "_shopify_function_input_get_interned_obj_prop"]
-extern "C" fn shopify_function_input_get_interned_obj_prop(
-    context: ContextPtr,
-    scope: u64,
-    interned_string_id: InternedStringId,
-) -> u64 {
-    match Context::ref_from_raw(context) {
-        Ok(context) => {
-            let v = NanBox::from_bits(scope);
-            match v.try_decode() {
-                Ok(NanBoxValueRef::Object { ptr: obj_ptr }) => {
-                    let query = context.string_interner.get(interned_string_id);
-                    let value = match LazyValueRef::mut_from_raw(obj_ptr as _) {
-                        Ok(value) => value,
-                        Err(e) => return NanBox::error(e).to_bits(),
-                    };
-                    match value.get_object_property(
-                        query,
-                        &context.input_bytes,
-                        &context.bump_allocator,
-                    ) {
-                        Ok(Some(value)) => value.encode().to_bits(),
-                        Ok(None) => NanBox::null().to_bits(),
-                        Err(e) => NanBox::error(e).to_bits(),
+decorate_for_target! {
+    fn shopify_function_input_get_interned_obj_prop(
+        context: ContextPtr,
+        scope: Val,
+        interned_string_id: InternedStringId,
+    ) -> Val {
+        match Context::ref_from_raw(context) {
+            Ok(context) => {
+                let v = NanBox::from_bits(scope);
+                match v.try_decode() {
+                    Ok(NanBoxValueRef::Object { ptr: obj_ptr }) => {
+                        let query = context.string_interner.get(interned_string_id);
+                        let value = match LazyValueRef::mut_from_raw(obj_ptr as _) {
+                            Ok(value) => value,
+                            Err(e) => return NanBox::error(e).to_bits(),
+                        };
+                        match value.get_object_property(
+                            query,
+                            &context.input_bytes,
+                            &context.bump_allocator,
+                        ) {
+                            Ok(Some(value)) => value.encode().to_bits(),
+                            Ok(None) => NanBox::null().to_bits(),
+                            Err(e) => NanBox::error(e).to_bits(),
+                        }
                     }
+                    Ok(_) => NanBox::error(ErrorCode::NotAnObject).to_bits(),
+                    Err(_) => NanBox::error(ErrorCode::DecodeError).to_bits(),
                 }
-                Ok(_) => NanBox::error(ErrorCode::NotAnObject).to_bits(),
-                Err(_) => NanBox::error(ErrorCode::DecodeError).to_bits(),
             }
+            Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
         }
-        Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
     }
 }
 
-#[export_name = "_shopify_function_input_get_at_index"]
-extern "C" fn shopify_function_input_get_at_index(
-    context: ContextPtr,
-    scope: u64,
-    index: u32,
-) -> u64 {
-    match Context::ref_from_raw(context) {
-        Ok(context) => {
-            let v = NanBox::from_bits(scope);
-            match v.try_decode() {
-                Ok(NanBoxValueRef::Array { ptr, len: _ }) => {
-                    let value = match LazyValueRef::mut_from_raw(ptr as _) {
-                        Ok(value) => value,
-                        Err(e) => return NanBox::error(e).to_bits(),
-                    };
-                    match value.get_at_index(
-                        index as usize,
-                        &context.input_bytes,
-                        &context.bump_allocator,
-                    ) {
-                        Ok(value) => value.encode().to_bits(),
-                        Err(e) => NanBox::error(e).to_bits(),
+decorate_for_target! {
+    fn shopify_function_input_get_at_index(
+        context: ContextPtr,
+        scope: Val,
+        index: usize,
+    ) -> Val {
+        match Context::ref_from_raw(context) {
+            Ok(context) => {
+                let v = NanBox::from_bits(scope);
+                match v.try_decode() {
+                    Ok(NanBoxValueRef::Array { ptr, len: _ }) => {
+                        let value = match LazyValueRef::mut_from_raw(ptr as _) {
+                            Ok(value) => value,
+                            Err(e) => return NanBox::error(e).to_bits(),
+                        };
+                        match value.get_at_index(
+                            index,
+                            &context.input_bytes,
+                            &context.bump_allocator,
+                        ) {
+                            Ok(value) => value.encode().to_bits(),
+                            Err(e) => NanBox::error(e).to_bits(),
+                        }
                     }
+                    Ok(_) => NanBox::error(ErrorCode::NotAnArray).to_bits(),
+                    Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
                 }
-                Ok(_) => NanBox::error(ErrorCode::NotAnArray).to_bits(),
-                Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
             }
+            Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
         }
-        Err(_) => NanBox::error(ErrorCode::ReadError).to_bits(),
     }
 }
 
-#[export_name = "_shopify_function_input_get_val_len"]
-extern "C" fn shopify_function_input_get_val_len(context: ContextPtr, scope: u64) -> usize {
-    match Context::ref_from_raw(context) {
-        Ok(_) => {
-            // don't actually need the context, but keeping it for consistency and to make it possible to use in the future if needed
-            let v = NanBox::from_bits(scope);
-            match v.try_decode() {
-                Ok(NanBoxValueRef::String { ptr, .. } | NanBoxValueRef::Array { ptr, .. }) => {
-                    let Ok(value) = LazyValueRef::mut_from_raw(ptr as _) else {
-                        return 0;
-                    };
-                    value.get_value_length()
+decorate_for_target! {
+    fn shopify_function_input_get_val_len(context: ContextPtr, scope: Val) -> usize {
+        match Context::ref_from_raw(context) {
+            Ok(_) => {
+                // don't actually need the context, but keeping it for consistency and to make it possible to use in the future if needed
+                let v = NanBox::from_bits(scope);
+                match v.try_decode() {
+                    Ok(NanBoxValueRef::String { ptr, .. } | NanBoxValueRef::Array { ptr, .. }) => {
+                        let Ok(value) = LazyValueRef::mut_from_raw(ptr as _) else {
+                            return 0;
+                        };
+                        value.get_value_length()
+                    }
+                    _ => 0,
                 }
-                _ => 0,
             }
+            Err(_) => 0,
         }
-        Err(_) => 0,
     }
 }
 
-#[export_name = "_shopify_function_input_get_utf8_str_addr"]
-extern "C" fn shopify_function_input_get_utf8_str_addr(context: ContextPtr, ptr: usize) -> usize {
-    match Context::ref_from_raw(context) {
-        Ok(context) => {
-            let Ok(value) = LazyValueRef::mut_from_raw(ptr as _) else {
-                return 0;
-            };
-            value.get_utf8_str_addr(&context.input_bytes)
+decorate_for_target! {
+    fn shopify_function_input_get_utf8_str_addr(
+        context: ContextPtr,
+        ptr: usize,
+    ) -> usize {
+        match Context::ref_from_raw(context) {
+            Ok(context) => {
+                let Ok(value) = LazyValueRef::mut_from_raw(ptr as _) else {
+                    return 0;
+                };
+                value.get_utf8_str_addr(&context.input_bytes)
+            }
+            Err(_) => 0,
         }
-        Err(_) => 0,
     }
 }


### PR DESCRIPTION
In the API crate, use the `provider` crate for non-Wasm targets, applying the few additions needed to replicate the trampoline behaviour.

Involved widening the `NanBox` to `u128` for 64 bit architectures, as we need the ability to store 64 bit addresses, which is admittedly a bit awkward.