### PR TITLE
Make it possible to test `Serialize` implementations

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -155,8 +155,8 @@ mod provider_fallback {
                 context, len,
             );
         let write_result =
-            WriteResult::from_repr((result >> 32) as u32).expect("Invalid write result");
-        let dst = result as u32;
+            WriteResult::from_repr((result >> usize::BITS) as usize).expect("Invalid write result");
+        let dst = result as usize;
         if write_result == WriteResult::Ok {
             std::ptr::copy(ptr as _, dst as _, len);
         }

--- a/core/src/write.rs
+++ b/core/src/write.rs
@@ -1,4 +1,4 @@
-#[repr(u32)]
+#[repr(usize)]
 #[derive(Debug, strum::FromRepr, PartialEq, Eq)]
 pub enum WriteResult {
     /// The write operation was successful.


### PR DESCRIPTION
Introduce a new `Context::finalize_output_and_return` method only available in non-Wasm targets that is analogous to the `Context::new_with_input` method. This makes it possible to unit test `Serialize` implementations. I don't expect Function authors to be implementing `Serialize` and need to test this, but it could be useful for `shopify-function-rust` to have this ability to unit test our implementations for custom scalars.