### PR TITLE
Provide data structure to make caching interned string IDs easy

### DIFF
--- a/api/examples/cart-checkout-validation-wasm-api.rs
+++ b/api/examples/cart-checkout-validation-wasm-api.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         array_ctx.write_object(
                             |error_ctx| {
                                 error_ctx.write_utf8_str("localizedMessage")?;
-                                error_ctx.write_utf8_str(&error)?;
+                                error_ctx.write_utf8_str(error)?;
 
                                 error_ctx.write_utf8_str("target")?;
                                 error_ctx.write_utf8_str("$.cart")?;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -260,7 +260,7 @@ impl CachedInternedStringId {
     pub const fn new(value: &'static str) -> Self {
         Self {
             value,
-            interned_string_id: AtomicUsize::new(0),
+            interned_string_id: AtomicUsize::new(usize::MAX),
             context: AtomicPtr::new(std::ptr::null_mut()),
         }
     }


### PR DESCRIPTION
Without this helper, it is easy to accidentally cache the interned string ID in a way that breaks when multiple tests run at the same time (likely), or a single test uses multiple contexts (unlikely but easily reproduces the issue). See the test added to `api/examples/echo.rs` for an example of a test that would fail with the naive memoization (the `OnceLock` approach that this PR removes from the `echo` example)