### PR TITLE
Make enums exposed in API crate non-exhaustive

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -481,6 +481,7 @@ pub struct Context(ContextPtr);
 
 /// An error that can occur when creating a [`Context`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ContextError {
     /// The pointer to the context is null.
     NullPointer,

--- a/api/src/read.rs
+++ b/api/src/read.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 /// An error that can occur when deserializing a value.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The value is not of the expected type.
     #[error("Invalid type")]

--- a/api/src/write.rs
+++ b/api/src/write.rs
@@ -10,6 +10,7 @@ use shopify_function_wasm_api_core::write::WriteResult;
 
 /// An error that can occur when writing a value.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// An I/O error occurred.
     #[error("I/O error")]

--- a/core/src/read.rs
+++ b/core/src/read.rs
@@ -218,6 +218,7 @@ impl Tag {
 /// An error code.
 #[derive(Debug, Clone, Copy, PartialEq, strum::EnumIter, strum::FromRepr)]
 #[repr(usize)]
+#[non_exhaustive]
 pub enum ErrorCode {
     /// The NanBox could not be decoded.
     DecodeError = 0,

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -34,8 +34,7 @@ fn assert_fuel_consumed_within_threshold(target_fuel: u64, fuel_consumed: u64) {
             target_fuel
         );
     } else if percentage_difference > THRESHOLD_PERCENTAGE {
-        assert!(
-            false,
+        panic!(
             "fuel_consumed ({}) was significantly better than target_fuel value ({}) by more than {:.2}%. This is a significant improvement! Please double check your changes and update the target fuel if this is a legitimate improvement.",
             fuel_consumed,
             target_fuel,
@@ -47,7 +46,7 @@ fn assert_fuel_consumed_within_threshold(target_fuel: u64, fuel_consumed: u64) {
 fn run_example(example: &str, input_bytes: Vec<u8>) -> Result<(Vec<u8>, u64)> {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let workspace_root = std::path::PathBuf::from(manifest_dir).join("..");
-    let engine = Engine::new(&Config::new().consume_fuel(true))?;
+    let engine = Engine::new(Config::new().consume_fuel(true))?;
 
     let module_path = workspace_root.join(format!(
         "target/wasm32-wasip1/release/examples/{example}.merged.wasm"


### PR DESCRIPTION
Make all enums publicly exposed from the API crate `#[non_exhaustive]` so that we can add to them without needing a major version bump (and still adhere to semver).

I did not do this for `ValueRef` and `WriteResult` from the core crate, as they are not publicly exposed in the API crate, so this isn't really a concern as the core crate is only intended to be used directly by the API and provider crates.

Also fixed a lint warning in the integration tests.

