### PR TITLE
Update API/core crate versions to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "integration_tests"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "deterministic-wasi-ctx",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_wasm_api"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "paste",
  "rmp-serde",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_wasm_api_core"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "strum",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_wasm_api"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/shopify-function-wasm-api"
@@ -8,7 +8,7 @@ homepage = "https://github.com/Shopify/shopify-function-wasm-api"
 description = "High-level interface for interfacing with the Shopify Function Wasm API"
 
 [dependencies]
-shopify_function_wasm_api_core = { path = "../core", version = "0.0.1" }
+shopify_function_wasm_api_core = { path = "../core", version = "0.1.0" }
 thiserror = "2.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_wasm_api_core"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/shopify-function-wasm-api"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_tests"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 rmp = "0.8.14"
-shopify_function_wasm_api_core = { path = "../core", version = "0.0.1" }
+shopify_function_wasm_api_core = { path = "../core", version = "0.1.0" }
 bumpalo = { version = "3.17.0", features = ["collections"] }
 
 [dev-dependencies]


### PR DESCRIPTION
I think we can release these as pre 1.0 as we don't expect developers to be using them directly