### PR TITLE
No-op for modules without memory in trampoline

### DIFF
--- a/trampoline/src/snapshots/shopify_function_trampoline__test__disassemble_trampoline@empty.wat.snap
+++ b/trampoline/src/snapshots/shopify_function_trampoline__test__disassemble_trampoline@empty.wat.snap
@@ -4,8 +4,6 @@ expression: actual
 input_file: trampoline/src/test_data/empty.wat
 ---
 (module
-  (memory (;0;) 1)
-  (export "memory" (memory 0))
   (@producers
     (processed-by "walrus" "0.23.3")
   )

--- a/trampoline/src/test_data/empty.wat
+++ b/trampoline/src/test_data/empty.wat
@@ -1,4 +1,1 @@
-(module
-    (memory 1)
-    (export "memory" (memory 0))
-)
+(module)


### PR DESCRIPTION
Javy modules don't have their own memory, and we want to support them