### PR TITLE
Update documentation for recompiling header_test.wasm

### DIFF
--- a/api/src/test_data/header_test.c
+++ b/api/src/test_data/header_test.c
@@ -2,8 +2,10 @@
 
 // Force the compiler to keep these imports by declaring function pointers
 // This file is needed to test the imports of the shopify_function.h file
+// To update this file you will need a compiler toolchain:
+// `brew install llvm lld`
 // On updating this file, regenerate the header_test.wasm file with the following command:
-// clang --target=wasm32-wasi -nostdlib -Wl,--no-entry -Wl,--export-all -Wl,--allow-undefined -o header_test.wasm header_test.c
+// `/opt/homebrew/opt/llvm/bin/clang --target=wasm32-wasip1 -I .. -nostdlib -Wl,--no-entry -Wl,--export-all -Wl,--allow-undefined -o header_test.wasm header_test.c`
 
 volatile void* imports[] = {
     (void*)shopify_function_context_new,


### PR DESCRIPTION
I found the existing instruction for recompiling `header_test.wasm` wasn't working for me. So I made two updates:
1. Include `-I ..` as an argument to clang so clang can find the `shopify_function.h` header file.
2. Use Homebrew's clang instead of the default MacOS clang. I found the default MacOS clang didn't include support for any Wasm targets. I've also added instructions on how to install the compiler and linker. Without explicitly installing `lld`, Clang couldn't find `wasm-ld`. I also updated the target name to specify preview 1.