### PR TITLE
v0.2.0 of API crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_wasm_api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "paste",
  "rmp-serde",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_wasm_api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/shopify-function-wasm-api"


### PR DESCRIPTION
Main changes are #86, #87, and #94. The first two are additive, so I went with 0.2.0 instead of 0.1.1.