### PR TITLE
Replace stdin with preinitialized input buffer

### DIFF
--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -14,7 +14,7 @@ pub const PROVIDER_MODULE_NAME: &str =
 
 #[cfg(target_family = "wasm")]
 thread_local! {
-    static INPUT: std::cell::RefCell<Vec<u8>> = std::cell::RefCell::new(Vec::new());
+    static INPUT: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -51,7 +51,7 @@ impl Context {
 
     #[cfg(target_family = "wasm")]
     fn new_from_buffer() -> Self {
-        let input_bytes = INPUT.with_borrow_mut(|input| std::mem::take(input));
+        let input_bytes = INPUT.with_borrow_mut(std::mem::take);
         Self::new(input_bytes)
     }
 


### PR DESCRIPTION
Instead of using WASI standard input to get input, have the host call an exported function to initialize an in-memory buffer for the input, then copy the input into the buffer, then reset the fuel counter and call the function. This excludes our code that loads the data from the limits imposed on the partner function (though we could choose to subject this function to the limits as well) and replaces _n_ hostcalls with a single call to an exported function to setup the input.