### PR TITLE
Add conditional field serialization to reduce output size

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -34,3 +34,7 @@ path = "examples/cart-checkout-validation-wasm-api.rs"
 name = "cart-checkout-validation-wasi-json"
 path = "examples/cart-checkout-validation-wasi-json.rs"
 
+[[example]]
+name = "null_fields"
+path = "../examples/null_fields.rs"
+

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -34,7 +34,7 @@ pub mod read;
 pub mod write;
 
 pub use read::Deserialize;
-pub use write::Serialize;
+pub use write::{ConditionalObjectWriter, Serialize, SerializeOptional};
 
 #[cfg(target_family = "wasm")]
 #[link(wasm_import_module = "shopify_function_v1")]

--- a/examples/null_fields.rs
+++ b/examples/null_fields.rs
@@ -1,0 +1,78 @@
+use shopify_function_wasm_api::{Context, Serialize};
+
+/// Example demonstrating how to avoid null fields in output
+/// This addresses the issue described in GitHub where the Rust output
+/// was including null attributes, image, and price fields.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Original approach - includes null fields
+    println!("=== Original approach (includes nulls) ===");
+    let mut context1 = Context::new_with_input(serde_json::json!({}));
+
+    let attributes: Option<String> = None;
+    let image: Option<String> = None;
+    let price: Option<f64> = None;
+    let merchandise_id = "gid://shopify/ProductVariant/456";
+    let quantity = 1;
+
+    context1.write_object(
+        |ctx| {
+            ctx.write_utf8_str("merchandiseId")?;
+            merchandise_id.serialize(ctx)?;
+
+            ctx.write_utf8_str("quantity")?;
+            quantity.serialize(ctx)?;
+
+            ctx.write_utf8_str("attributes")?;
+            attributes.serialize(ctx)?; // This writes null
+
+            ctx.write_utf8_str("image")?;
+            image.serialize(ctx)?; // This writes null
+
+            ctx.write_utf8_str("price")?;
+            price.serialize(ctx)?; // This writes null
+
+            Ok(())
+        },
+        5,
+    )?;
+
+    let result1 = context1.finalize_output_and_return()?;
+    println!(
+        "Output with nulls: {}",
+        serde_json::to_string_pretty(&result1)?
+    );
+
+    // New ergonomic approach - skips null fields automatically!
+    println!("\n=== New approach (skips nulls) ===");
+    let mut context3 = Context::new_with_input(serde_json::json!({}));
+
+    context3.write_object_with_conditional_fields(|writer| {
+        // Automatically handles key writing and field counting
+        writer.field("merchandiseId", merchandise_id)?;
+        writer.field("quantity", &quantity)?;
+        writer.optional_field("attributes", &attributes)?; // Skipped automatically if None
+        writer.optional_field("image", &image)?; // Skipped automatically if None
+        writer.optional_field("price", &price)?; // Skipped automatically if None
+        Ok(())
+    })?;
+
+    let result2 = context3.finalize_output_and_return()?;
+    println!(
+        "Output with ergonomic API: {}",
+        serde_json::to_string_pretty(&result2)?
+    );
+
+    // Show size difference
+    let size1 = serde_json::to_vec(&result1)?.len();
+    let size2 = serde_json::to_vec(&result2)?.len();
+    println!("\nSize comparison:");
+    println!("With nulls: {} bytes", size1);
+    println!("Without nulls (ergonomic API): {} bytes", size2);
+    println!(
+        "Savings: {} bytes ({:.1}%)",
+        size1 - size2,
+        (size1 - size2) as f32 / size1 as f32 * 100.0
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This PR adds optional field serialization capabilities that will skip `null` fields in object output.

## Background

From the discussion in the Slack thread, the current implementation always serializes `Option<T>` values as either the actual value or `null`. This PR provides an **opt-in solution** by adding the `SerializeOptional` method.

## Changes

1. **`SerializeOptional` trait** - Provides conditional serialization for `Option<T>`
2. **`FieldCounter` helper** - Counts fields before writing to determine correct object size
3. **`write_object_conditional` method** - Enables dynamic object writing with field counting

## API Usage

### Before (always writes nulls)
```rust
context.write_object(|ctx| {
    ctx.write_utf8_str("attributes")?;
    attributes.serialize(ctx)?; // Always writes null if None
    
    ctx.write_utf8_str("price")?;
    price.serialize(ctx)?; // Always writes null if None
    
    Ok(())
}, 2)?;
```

### After (automatic null field skipping)
```rust
// New API - automatically skips fields that are None
context.write_object_with_conditional_fields(|writer| {
    writer.field("merchandiseId", &merchandise_id)?;     // Always included
    writer.field("quantity", &quantity)?;                // Always included
    writer.optional_field("attributes", &attributes)?;   // Skipped if None
    writer.optional_field("price", &price)?;             // Skipped if None
    Ok(())
})?;
```

## Performance Impact

Based on the example I added `null_fields.rs` .:
- **Size reduction**: 40.4% smaller output (109 bytes → 65 bytes)
- **Overhead**: Minimal - requires one counting pass before writing

## Backward Compatibility
- Existing `Option<T>` serialization behavior unchanged
- New functionality is purely additive
- No breaking changes to existing APIs
- Can be released as a patch version 

## Testing
- added test verifying null fields skipped
- 

## Example Output

**With null fields (current behavior):**
```json
{
  "attributes": null,
  "image": null,
  "merchandiseId": "gid://shopify/ProductVariant/456",
  "price": null,
  "quantity": 1
}
```

**Without null fields (new behavior):**
```json
{
  "merchandiseId": "gid://shopify/ProductVariant/456",
  "quantity": 1
}
```

## Review Notes
- Tried to implement Adam identified as necessary for dynamic object sizing while maintaining full backward compatibility. The feature is opt-in, addressing the size optimization without affecting existing current functions (if any) who rely on null field presence