### PR TITLE
Fix compiler warnings

### DIFF
--- a/provider/src/read/lazy_value_ref.rs
+++ b/provider/src/read/lazy_value_ref.rs
@@ -625,7 +625,7 @@ impl<'a> LazyValueRef<'a> {
         index: usize,
         bytes: &[u8],
         bump: &'a Bump,
-    ) -> Result<&LazyValueRef, ErrorCode> {
+    ) -> Result<&LazyValueRef<'_>, ErrorCode> {
         match self {
             Self::Array(array_ref) => array_ref.get_at_index(index, bytes, bump),
             Self::Object(obj_ref) => obj_ref.get_at_index(index, bytes, bump).map(|v| &v.1),
@@ -638,7 +638,7 @@ impl<'a> LazyValueRef<'a> {
         index: usize,
         bytes: &[u8],
         bump: &'a Bump,
-    ) -> Result<&LazyValueRef, ErrorCode> {
+    ) -> Result<&LazyValueRef<'_>, ErrorCode> {
         match self {
             Self::Object(obj_ref) => obj_ref.get_at_index(index, bytes, bump).map(|v| &v.0),
             _ => Err(ErrorCode::NotAnObject),


### PR DESCRIPTION
I noticed we are seeing a couple compiler warnings in `main` so this fixes them.