### PR TITLE
Validate modules and show full error chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,7 @@ dependencies = [
  "predicates",
  "uuid",
  "walrus",
+ "wasmparser 0.238.0",
  "wasmprinter 0.235.0",
  "wat",
 ]
@@ -2385,6 +2386,19 @@ dependencies = [
  "bitflags",
  "indexmap 2.8.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.238.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ad4ca2ecb86b79ea410cd970985665de1d05774b7107b214bc5852b1bcbad7"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]

--- a/trampoline/Cargo.toml
+++ b/trampoline/Cargo.toml
@@ -11,6 +11,7 @@ description = "Tool for augmenting Wasm modules to be compatible with the Shopif
 walrus = "0.23.3"
 anyhow = "1.0"
 clap = { version = "4.5.41", features = ["derive"] }
+wasmparser = "0.238.0"
 
 [dev-dependencies]
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/trampoline/src/main.rs
+++ b/trampoline/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, process};
 
 use clap::Parser;
 use shopify_function_trampoline::trampoline_existing_module;
@@ -18,5 +18,9 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    trampoline_existing_module(args.input, args.output)
+    if let Err(err) = trampoline_existing_module(args.input, args.output) {
+        eprintln!("Error: {err:?}");
+        process::exit(1);
+    }
+    Ok(())
 }


### PR DESCRIPTION
This makes three changes:
1. The binary will now show the full chain with any error message as opposed to just the outer error message.
2. Failure to validate input modules will now have a new outer error message attached.
3. Modules are now validated before they are output and will return an error message saying validating the output module failed if they are invalid.

The reason for this change is if the trampoline produces invalid Wasm, using that output will result in function-runner and runtime-engine's validator returning a validation error but it won't be obvious that the transformation performed in the trampoline was the source of the invalid Wasm. So this will help narrow down the source of the problem faster for partners and for us when we're doing development.

I'm also planning on adding some more validation checks in future PRs around function imports using incorrect types but I don't think it hurts to have something to catch invalid modules sooner rather than later since invalid modules will _always_ fail to instantiate.