### PR TITLE
Validate version in import module names

### DIFF
--- a/trampoline/src/lib.rs
+++ b/trampoline/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{bail, Context};
 use std::cell::OnceCell;
 use std::path::Path;
 use walrus::{
@@ -470,6 +470,15 @@ impl TrampolineCodegen {
             return Ok(self.module);
         }
 
+        if let Some(unsupported_import) = self.module.imports.iter().find(|import| {
+            import.module.starts_with("shopify_function_v") && import.module != PROVIDER_MODULE_NAME
+        }) {
+            bail!(
+                "Imports from module named `{}` are not supported. Imports must be from `{PROVIDER_MODULE_NAME}`. If you are using Rust, ensure you are using an up-to-date Shopify CLI and `shopify_function` Rust crate.",
+                unsupported_import.module
+            );
+        }
+
         for (original, new) in IMPORTS {
             match *original {
                 "shopify_function_input_read_utf8_str" => {
@@ -557,6 +566,22 @@ mod test {
         assert_eq!(
             err.to_string(),
             "multiple non-imported memories are not supported"
+        );
+    }
+
+    #[test]
+    fn test_import_from_unsupported_function_module() {
+        let module = r#"
+        (module
+            (import "shopify_function_v2" "foo" (func))
+            (memory 1)
+        )
+        "#;
+        let result = trampoline_wat(module.as_bytes());
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Imports from module named `shopify_function_v2` are not supported. Imports must be from `shopify_function_v1`. If you are using Rust, ensure you are using an up-to-date Shopify CLI and `shopify_function` Rust crate."
         );
     }
 


### PR DESCRIPTION
Validates that the input module imports from `shopify_function_v1` and not a different `shopify_function_v` module and emits an error message to the terminal a non-zero exit code if not.

The reason for this change is we will have a new version of the Wasm API soon and the trampoline only operates on one version so if the partner developer uses a different version of the Wasm API than is supported by the trampoline, their imports won't be transformed as expected and the output module will fail to instantiate when run in function-runner or when validating on deploy from the Shopify CLI. As well, for partner developers using Rust, the version of the Wasm API that is imported will depend on the version of the `shopify_function` Rust crate their Function is built with so there is a possibility that they may try to use a trampoline version that would not transform the imports used in their Function if they aren't using a compatible Rust crate version. For partner developers using the Wasm API and who are not using Rust, we will still likely want the trampoline to emit an error if they are using an unexpected version of the Wasm API.

Another option I considered was supporting the existing Wasm API and the new Wasm API in the upcoming changes to the trampoline but was advised offline not to take this approach because it increases the maintenance burden and we want to encourage partner developers to keep their Shopify CLI and Rust crates up-to-date.

Unfortunately this change will not apply retroactively to already shipped versions of the trampoline so will continue to be possible for users of already shipped versions of the trampoline to see validation and instantiation errors if they were to try to use the next version of the Wasm API without updating their Shopify CLI. I can't think of a good way to mitigate that.