### PR TITLE
Add Windows on AArch64 build artifact for trampoline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,11 @@ jobs:
             path: target\x86_64-pc-windows-msvc\release\shopify_function_trampoline.exe
             shasum_cmd: sha256sum
             target: x86_64-pc-windows-msvc
+          - name: arm-windows
+            os: windows-latest
+            path: target\aarch64-pc-windows-msvc\release\shopify_function_trampoline.exe
+            shasum_cmd: sha256sum
+            target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Windows on AArch64 is now [a tier 1 target](https://doc.rust-lang.org/beta/rustc/platform-support.html#tier-1-with-host-tools) in Rust so we may as well support it since one of our teams uses it for QA'ing the Shopify CLI.