### PR TITLE
Trampoline v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_trampoline"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/trampoline/Cargo.toml
+++ b/trampoline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_trampoline"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/shopify-function-wasm-api"


### PR DESCRIPTION
Increment patch version of trampoline so we can create a release with a Windows on AArch64 artifact.