### PR TITLE
Fix string interner unit test bug

### DIFF
--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -109,7 +109,13 @@ extern "C" fn initialize(input_len: usize) -> *const u8 {
 
 #[cfg(not(target_family = "wasm"))]
 pub fn initialize_from_msgpack_bytes(bytes: Vec<u8>) {
-    CONTEXT.with_borrow_mut(|context| *context = Context::new(bytes))
+    CONTEXT.with_borrow_mut(|context| {
+        use std::mem;
+
+        let string_interner = mem::take(&mut context.string_interner);
+        *context = Context::new(bytes);
+        context.string_interner = string_interner;
+    })
 }
 
 #[cfg(target_family = "wasm")]

--- a/provider/src/string_interner.rs
+++ b/provider/src/string_interner.rs
@@ -1,6 +1,7 @@
 use core::ffi::c_void;
 use shopify_function_wasm_api_core::InternedStringId;
 
+#[derive(Default)]
 pub(crate) struct StringInterner {
     buf: Vec<u8>,
     spans: Vec<(usize, usize)>,


### PR DESCRIPTION
I discovered while trying to update the templates that we are declaring `CachedInternedStringId` values statically which I was not aware of. My existing implementation works when we don't reset the context and there aren't multiple threads. Unfortunately it does not work when those two cases aren't true like in unit tests.

So this PR does three things:
1. Adjust the tests so we declare a `CachedInternedStringId` statically and use it across multiple contexts, multiple tests, and multiple threads as is the case with how we use it in practice.
2. Re-use the existing string interner when creating a new context for unit tests to cover the same thread case.
3. Change the Rust crate to use a thread local cache of strings to interned string ids so this will work across threads.

Some alternative approaches we could consider:
- Make the string interner a static `RwLock` value. This should keep the interned values consistent across threads and contexts. It's also not applicable outside the use case of running unit tests with Rust so it seems like that might be the wrong layer to solve it at.
- Make the string interner a static value separate from context so it's not affected when a new context is created in tests. I'd be open to making that change.
- For the interned string id caching, use a hashing implementation that will use string addresses instead of string contents for equality and hash values. I'd imagine this would be faster than hashing the string contents but it would complicate the code.
- I did investigate reintroducing some notion of context id for string interning in the `api` crate using a combination of a thread id and a value we increment every time we create a new context to emulate what we were doing before my changes. It seemed like a bit of a fragile approach if we didn't also update the developer facing API to reincorporate a context identifier.