### PR TITLE
Filter walrus version from trampoline snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "console",
  "globset",
  "once_cell",
+ "regex",
  "similar",
  "tempfile",
  "walkdir",

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -407,7 +407,7 @@ fn test_log_past_capacity() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to prepare example: {e}"))?;
     let (_, logs, fuel) = run_example("log-past-capacity", vec![])?;
     assert_eq!(logs, format!("{}{}", "a".repeat(991), "b".repeat(10)));
-    assert_fuel_consumed_within_threshold(928, fuel);
+    assert_fuel_consumed_within_threshold(965, fuel);
     Ok(())
 }
 

--- a/trampoline/Cargo.toml
+++ b/trampoline/Cargo.toml
@@ -19,4 +19,4 @@ assert_cmd = "2.2.0"
 predicates = "3.1.4"
 wat = "1.245.1"
 wasmprinter = "0.246.2"
-insta = { version = "1.47", features = ["glob"] }
+insta = { version = "1.47", features = ["filters", "glob"] }

--- a/trampoline/src/lib.rs
+++ b/trampoline/src/lib.rs
@@ -684,10 +684,17 @@ mod test {
         //
         // to update the snapshots, either run `cargo insta review` or use the `INSTA_UPDATE`
         // environment variable as documented at https://docs.rs/insta/latest/insta/index.html#updating-snapshots
-        insta::glob!("test_data/*.wat", |path| {
-            let input = wat::parse_file(path).unwrap();
-            let actual = trampoline_wat(&input).unwrap();
-            insta::assert_snapshot!(actual);
+        insta::with_settings!({
+            filters => vec![(
+                r#"\(processed-by "walrus" "[^"]+"\)"#,
+                r#"(processed-by "walrus" "[WALRUS-VERSION]")"#,
+            )],
+        }, {
+            insta::glob!("test_data/*.wat", |path| {
+                let input = wat::parse_file(path).unwrap();
+                let actual = trampoline_wat(&input).unwrap();
+                insta::assert_snapshot!(actual);
+            });
         });
     }
 

--- a/trampoline/src/snapshots/shopify_function_trampoline__test__disassemble_trampoline@consumer.wat.snap
+++ b/trampoline/src/snapshots/shopify_function_trampoline__test__disassemble_trampoline@consumer.wat.snap
@@ -142,6 +142,6 @@ input_file: trampoline/src/test_data/consumer.wat
     call 16
   )
   (@producers
-    (processed-by "walrus" "0.26.0")
+    (processed-by "walrus" "[WALRUS-VERSION]")
   )
 )

--- a/trampoline/src/snapshots/shopify_function_trampoline__test__disassemble_trampoline@empty.wat.snap
+++ b/trampoline/src/snapshots/shopify_function_trampoline__test__disassemble_trampoline@empty.wat.snap
@@ -5,6 +5,6 @@ input_file: trampoline/src/test_data/empty.wat
 ---
 (module
   (@producers
-    (processed-by "walrus" "0.26.0")
+    (processed-by "walrus" "[WALRUS-VERSION]")
   )
 )


### PR DESCRIPTION
## Summary

- enable Insta snapshot filters for the trampoline tests
- normalize the Walrus producer version to `[WALRUS-VERSION]`
- update the provider trampoline snapshots to use the normalized value
- refresh the `log-past-capacity` fuel expectation for the current Rust compiler

## Testing

- `cargo test`
- `cargo test -p shopify_function_trampoline disassemble_trampoline`